### PR TITLE
fix: remove parentheses from Arabic RTL text to fix display issues

### DIFF
--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -393,7 +393,8 @@
   "tryAgainLater": "يرجى المحاولة لاحقًا",
   "hintTextRtspUrl": "rtsp://... أو https://youtube.com/live/...",
   "checkInternetUpdate": "يجب عليك الاتصال بالإنترنت للتحقق من وجود تحديثات جديدة",
-  "appUpdateAvailable": "تطبيقك يعمل بالإصدار {currentVersion}. الإصدار الجديد {updatedVersion} متوفر مع أحدث الميزات والتحسينات.",  "@appUpdateAvailable": {
+  "appUpdateAvailable": "تطبيقك يعمل بالإصدار {currentVersion}. الإصدار الجديد {updatedVersion} متوفر مع أحدث الميزات والتحسينات.",
+  "@appUpdateAvailable": {
     "description": "Placeholder text for displaying update available message",
     "placeholders": {
       "currentVersion": {

--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -393,8 +393,7 @@
   "tryAgainLater": "يرجى المحاولة لاحقًا",
   "hintTextRtspUrl": "rtsp://... أو https://youtube.com/live/...",
   "checkInternetUpdate": "يجب عليك الاتصال بالإنترنت للتحقق من وجود تحديثات جديدة",
-  "appUpdateAvailable": "تطبيقك يعمل بالإصدار {currentVersion}. تحديث جديد (الإصدار {updatedVersion}) متوفر مع أحدث الميزات والتحسينات.",
-  "@appUpdateAvailable": {
+  "appUpdateAvailable": "تطبيقك يعمل بالإصدار {currentVersion}. الإصدار الجديد {updatedVersion} متوفر مع أحدث الميزات والتحسينات.",  "@appUpdateAvailable": {
     "description": "Placeholder text for displaying update available message",
     "placeholders": {
       "currentVersion": {


### PR DESCRIPTION
## Summary
- Removes ASCII parentheses from Arabic `appUpdateAvailable` localization string that were displaying reversed in RTL text on Android
- Flutter's text engine on Android does not properly handle parentheses in mixed RTL/LTR text, causing `(الإصدار 1.31.0)` to render as `)الإصدار 1.31.0(`
- Restructured the sentence to convey the same meaning without parentheses

Closes [#1946](https://github.com/mawaqit/mawaqit-tv-l10n/pull/17)

<img width="606" height="227" alt="image" src="https://github.com/user-attachments/assets/ae1a67b2-87b9-4794-976e-6a772419911e" />

