### PR TITLE
feat: add Quran mode localization keys

### DIFF
--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -471,5 +471,11 @@
   "testAITranslation": "هذه سلسلة اختبار للتحقق من أن ترجمة الذكاء الاصطناعي تعمل بشكل صحيح",
   "@testAITranslation": {
     "description": "Test string for AI translation verification - can be deleted after testing"
-  }
+  },
+  "quranMode": "وضع القرآن",
+  "quranModeExplanation": "عرض شاشة قراءة القرآن، بدءاً من آخر صفحة تمت قراءتها",
+  "appDisplayMode": "وضع العرض",
+  "appDisplayModeExplanation": "اختر كيفية عرض المحتوى على شاشتك",
+  "exitQuranModeTitle": "الخروج من وضع القرآن",
+  "exitQuranModeMessage": "هل تريد العودة إلى الوضع العادي؟"
 }

--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -481,5 +481,29 @@
   "testCrowdinCI": "Test string to verify Crowdin CI workflow on develop",
   "@testCrowdinCI": {
     "description": "Test string for Crowdin CI verification - can be deleted after testing"
+  },
+  "quranMode": "Quran mode",
+  "@quranMode": {
+    "description": "Label for Quran mode option in display mode settings"
+  },
+  "quranModeExplanation": "Display the Quran reading screen, starting from the last read page",
+  "@quranModeExplanation": {
+    "description": "Explanation text for the Quran mode option"
+  },
+  "appDisplayMode": "Display Mode",
+  "@appDisplayMode": {
+    "description": "Title for the display mode setting"
+  },
+  "appDisplayModeExplanation": "Choose how your screen will display content",
+  "@appDisplayModeExplanation": {
+    "description": "Subtitle for the display mode setting"
+  },
+  "exitQuranModeTitle": "Exit Quran Mode",
+  "@exitQuranModeTitle": {
+    "description": "Title for the exit Quran mode confirmation dialog"
+  },
+  "exitQuranModeMessage": "Would you like to return to normal mode?",
+  "@exitQuranModeMessage": {
+    "description": "Message body for the exit Quran mode confirmation dialog"
   }
 }

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -471,5 +471,11 @@
   "testAITranslation": "Ceci est une chaîne de test pour vérifier que la traduction de l'IA fonctionne correctement",
   "@testAITranslation": {
     "description": "Test string for AI translation verification - can be deleted after testing"
-  }
+  },
+  "quranMode": "Mode Coran",
+  "quranModeExplanation": "Afficher l'écran de lecture du Coran, en commençant par la dernière page lue",
+  "appDisplayMode": "Mode d'affichage",
+  "appDisplayModeExplanation": "Choisissez comment votre écran affichera le contenu",
+  "exitQuranModeTitle": "Quitter le mode Coran",
+  "exitQuranModeMessage": "Souhaitez-vous revenir au mode normal ?"
 }


### PR DESCRIPTION
## Summary
- Add localization keys for the Quran mode feature (PR mawaqit/android-tv-app#2077)
- Keys added: `quranMode`, `quranModeExplanation`, `appDisplayMode`, `appDisplayModeExplanation`, `exitQuranModeTitle`, `exitQuranModeMessage`
- Languages: English, Arabic, French

## Context
These keys are required by the Android TV app's new Quran Mode feature, which adds a dedicated Quran reading mode to the app settings.