### PR TITLE
chore: regenerate l10n files for pre-prod and environment keys

### DIFF
--- a/lib/src/generated/mawaqit_tv_localizations_ar.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ar.dart
@@ -52,16 +52,16 @@ class MawaqitTvLocalizationsAr extends MawaqitTvLocalizations {
   String get forceStaging => 'الانتقال إلى بيئة التهيئة';
 
   @override
-  String get forcePreProduction => 'Switch to pre-production';
+  String get forcePreProduction => 'الانتقال إلى بيئة ما قبل التهيئة';
 
   @override
   String get disableStaging => 'الانتقال إلى بيئة الاختبار';
 
   @override
-  String get environmentSwitchSuccess => 'Environment switched successfully';
+  String get environmentSwitchSuccess => 'تم تغيير الإعدادات بنجاح';
 
   @override
-  String get environmentSwitchFailed => 'Failed to switch environment';
+  String get environmentSwitchFailed => 'فشل تغيير الإعدادات';
 
   @override
   String get sureCloseApp => 'هل أنت متأكد أنك تريد الخروج من التطبيق؟';
@@ -408,7 +408,7 @@ class MawaqitTvLocalizationsAr extends MawaqitTvLocalizations {
   String get announcementOnlyModeEXPLINATION => 'اختر إذا كنت تود أن تعرض شاشة الإعلانات طوال الوقت، هذا يمكن أن يكون مفيداً إذا قمت بتثبيت الشاشة على سبيل المثال في المدخل.';
 
   @override
-  String get duaaElEftarText => 'اللهم اني لگ صمت وعلى رزقك افطرت واليك انبت وعليگ توكلت ذهب الظما وابتلت العروق وثبت الاجر انشاء الله';
+  String get duaaElEftarText => 'اللهم اني لگ صمت وعلى رزقك افطرت واليك انبت وعليگ توكلت ذهب الظما وابتلت العروق وثبت الاجر ان شاء الله';
 
   @override
   String get secondaryScreenExplanation => 'غرفة الصلاة الثانوية (غرفة النساء أو طابق آخر على سبيل المثال)، ستظهر هذه الشاشة البث المباشر للجمعة إذا تم تفعيله على حساب MAWAQIT';

--- a/lib/src/generated/mawaqit_tv_localizations_fr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_fr.dart
@@ -49,19 +49,19 @@ class MawaqitTvLocalizationsFr extends MawaqitTvLocalizations {
   String get quit => 'Quitter';
 
   @override
-  String get forceStaging => 'Passer en préproduction';
+  String get forceStaging => 'Passer en staging';
 
   @override
-  String get forcePreProduction => 'Switch to pre-production';
+  String get forcePreProduction => 'Passer en pre-production';
 
   @override
   String get disableStaging => 'Passer en mode production';
 
   @override
-  String get environmentSwitchSuccess => 'Environment switched successfully';
+  String get environmentSwitchSuccess => 'Environnement changé avec succès';
 
   @override
-  String get environmentSwitchFailed => 'Failed to switch environment';
+  String get environmentSwitchFailed => 'Échec du changement d\'environnement';
 
   @override
   String get sureCloseApp => 'Voulez-vous vraiment quitter l\'application ?';


### PR DESCRIPTION
## Summary
- Regenerated localization files after merging PRs that added new translation keys
- Updates AR and FR generated Dart files with translated values for `forcePreProduction`, `environmentSwitchSuccess`, and `environmentSwitchFailed` keys
- Ran `flutter gen-l10n` to produce the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)