### PR TITLE
feat(l10n): add continueListening key to all locales

### DIFF
--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -345,6 +345,7 @@
       }
     }
   },
+  "continueListening": "متابعة الاستماع",
   "noFavoriteReciters": "لا يوجد مقرئون مفضلون. حاول إضافة واحد إلى القائمة",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -345,7 +345,7 @@
       }
     }
   },
-  "continueListening": "متابعة الاستماع",
+  "continueListening": "مواصلة الاستماع",
   "noFavoriteReciters": "لا يوجد مقرئون مفضلون. حاول إضافة واحد إلى القائمة",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_az.arb
+++ b/l10n/intl_az.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Dinləməyə davam et",
   "noFavoriteReciters": "Sevimli qiraətçiniz yoxdur. Birini siyahıya əlavə edin",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_az.arb
+++ b/l10n/intl_az.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Sevimli qiraətçiniz yoxdur. Birini siyahıya əlavə edin",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_az.arb
+++ b/l10n/intl_az.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Dinləməyə davam et",
+  "continueListening": "Dinləməyə davam edin",
   "noFavoriteReciters": "Sevimli qiraətçiniz yoxdur. Birini siyahıya əlavə edin",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ba.arb
+++ b/l10n/intl_ba.arb
@@ -169,5 +169,5 @@
   "salatKhayrMinaNawm": "Әссәләтү Хәйрүм Минән Нәүм",
   "salatElEid": "Salat El Eid"
 ,
-  "continueListening": "Continue listening"
+  "continueListening": "Тыңлауҙы дауам итеү"
 }

--- a/l10n/intl_ba.arb
+++ b/l10n/intl_ba.arb
@@ -168,4 +168,6 @@
   "duaaBetweenSalahAndAdhan": "Anas bin Malik said: The Messenger of Allah (ﷺ) said: The supplication does not return between the call to prayer and the standing for prayer.",
   "salatKhayrMinaNawm": "Әссәләтү Хәйрүм Минән Нәүм",
   "salatElEid": "Salat El Eid"
+,
+  "continueListening": "Continue listening"
 }

--- a/l10n/intl_ba.arb
+++ b/l10n/intl_ba.arb
@@ -169,5 +169,5 @@
   "salatKhayrMinaNawm": "Әссәләтү Хәйрүм Минән Нәүм",
   "salatElEid": "Salat El Eid"
 ,
-  "continueListening": "Тыңлауҙы дауам итеү"
+  "continueListening": "Тыңлауҙы дауам ит"
 }

--- a/l10n/intl_ba.arb
+++ b/l10n/intl_ba.arb
@@ -169,5 +169,5 @@
   "salatKhayrMinaNawm": "Әссәләтү Хәйрүм Минән Нәүм",
   "salatElEid": "Salat El Eid"
 ,
-  "continueListening": "Тыңлауҙы дауам ит"
+  "continueListening": "Артабан тыңлау"
 }

--- a/l10n/intl_bg.arb
+++ b/l10n/intl_bg.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Няма любими рецитатори. Опитайте се да добавите някой в списъка",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bg.arb
+++ b/l10n/intl_bg.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Продължи слушането",
+  "continueListening": "Продължете да слушате",
   "noFavoriteReciters": "Няма любими рецитатори. Опитайте се да добавите някой в списъка",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bg.arb
+++ b/l10n/intl_bg.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Продължи слушането",
   "noFavoriteReciters": "Няма любими рецитатори. Опитайте се да добавите някой в списъка",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bn.arb
+++ b/l10n/intl_bn.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "পছন্দের কোনো তেলাওয়াতকারি নেই। একজন কে তালিকায় যোগ করুন",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bn.arb
+++ b/l10n/intl_bn.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "শোনা চালিয়ে যান",
+  "continueListening": "শুনতে থাকুন",
   "noFavoriteReciters": "পছন্দের কোনো তেলাওয়াতকারি নেই। একজন কে তালিকায় যোগ করুন",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bn.arb
+++ b/l10n/intl_bn.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "শোনা চালিয়ে যান",
   "noFavoriteReciters": "পছন্দের কোনো তেলাওয়াতকারি নেই। একজন কে তালিকায় যোগ করুন",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bs.arb
+++ b/l10n/intl_bs.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bs.arb
+++ b/l10n/intl_bs.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušanje",
+  "continueListening": "Nastavi slušati",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bs.arb
+++ b/l10n/intl_bs.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Nastavi slušanje",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_bs.arb
+++ b/l10n/intl_bs.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušati",
+  "continueListening": "Nastavite sa slušanjem",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ca.arb
+++ b/l10n/intl_ca.arb
@@ -169,5 +169,5 @@
   "salatKhayrMinaNawm": "Assalatu khayrun mina nawm",
   "salatElEid": "Salat El Eid"
 ,
-  "continueListening": "Continue listening"
+  "continueListening": "Continua escoltant"
 }

--- a/l10n/intl_ca.arb
+++ b/l10n/intl_ca.arb
@@ -168,4 +168,6 @@
   "duaaBetweenSalahAndAdhan": "Anas bin Malik said: The Messenger of Allah (ﷺ) said: The supplication does not return between the call to prayer and the standing for prayer.",
   "salatKhayrMinaNawm": "Assalatu khayrun mina nawm",
   "salatElEid": "Salat El Eid"
+,
+  "continueListening": "Continue listening"
 }

--- a/l10n/intl_ca.arb
+++ b/l10n/intl_ca.arb
@@ -169,5 +169,5 @@
   "salatKhayrMinaNawm": "Assalatu khayrun mina nawm",
   "salatElEid": "Salat El Eid"
 ,
-  "continueListening": "Continua escoltant"
+  "continueListening": "Continueu escoltant"
 }

--- a/l10n/intl_cnr.arb
+++ b/l10n/intl_cnr.arb
@@ -335,7 +335,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Nastavi slušanje",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_cnr.arb
+++ b/l10n/intl_cnr.arb
@@ -335,7 +335,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušanje",
+  "continueListening": "Nastavite sa slušanjem",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_cnr.arb
+++ b/l10n/intl_cnr.arb
@@ -335,6 +335,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_cs.arb
+++ b/l10n/intl_cs.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Žádné oblíbené čtenáře. Zkuste přidat jeden do seznamu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_cs.arb
+++ b/l10n/intl_cs.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Pokračovat v poslechu",
   "noFavoriteReciters": "Žádné oblíbené čtenáře. Zkuste přidat jeden do seznamu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_cs.arb
+++ b/l10n/intl_cs.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Pokračovat v poslechu",
+  "continueListening": "Poslouchejte dál",
   "noFavoriteReciters": "Žádné oblíbené čtenáře. Zkuste přidat jeden do seznamu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_da.arb
+++ b/l10n/intl_da.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Ingen foretrukne reciters. Prøv at tilføje en til listen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_da.arb
+++ b/l10n/intl_da.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Fortsæt med at lytte",
   "noFavoriteReciters": "Ingen foretrukne reciters. Prøv at tilføje en til listen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_de.arb
+++ b/l10n/intl_de.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Keine Lieblings-Reziter. Versuche einen zur Liste hinzuzufügen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_de.arb
+++ b/l10n/intl_de.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Weiter hören",
   "noFavoriteReciters": "Keine Lieblings-Reziter. Versuche einen zur Liste hinzuzufügen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_de.arb
+++ b/l10n/intl_de.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Weiter hören",
+  "continueListening": "Weiter anhören",
   "noFavoriteReciters": "Keine Lieblings-Reziter. Versuche einen zur Liste hinzuzufügen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_de.arb
+++ b/l10n/intl_de.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Weiter anhören",
+  "continueListening": "Hören Sie weiter zu",
   "noFavoriteReciters": "Keine Lieblings-Reziter. Versuche einen zur Liste hinzuzufügen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_el.arb
+++ b/l10n/intl_el.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Δεν υπάρχουν αγαπημένες ρεσιτόρ. Προσπαθήστε να προσθέσετε ένα στη λίστα",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_el.arb
+++ b/l10n/intl_el.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Συνέχεια ακρόασης",
   "noFavoriteReciters": "Δεν υπάρχουν αγαπημένες ρεσιτόρ. Προσπαθήστε να προσθέσετε ένα στη λίστα",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_el.arb
+++ b/l10n/intl_el.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Συνέχεια ακρόασης",
+  "continueListening": "Συνεχίστε να ακούτε",
   "noFavoriteReciters": "Δεν υπάρχουν αγαπημένες ρεσιτόρ. Προσπαθήστε να προσθέσετε ένα στη λίστα",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -347,6 +347,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "No favorite reciters. Try adding one to the list",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_es.arb
+++ b/l10n/intl_es.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continuar escuchando",
+  "continueListening": "Seguir escuchando",
   "noFavoriteReciters": "No hay recetarios favoritos. Intenta añadir uno a la lista",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_es.arb
+++ b/l10n/intl_es.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "No hay recetarios favoritos. Intenta añadir uno a la lista",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_es.arb
+++ b/l10n/intl_es.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Continuar escuchando",
   "noFavoriteReciters": "No hay recetarios favoritos. Intenta añadir uno a la lista",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_et.arb
+++ b/l10n/intl_et.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Jätka kuulamist",
+  "continueListening": "Jätkake kuulamist",
   "noFavoriteReciters": "Ühtegi lemmikretsitaatorit pole. Proovi lisada nimekirja",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_et.arb
+++ b/l10n/intl_et.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Ühtegi lemmikretsitaatorit pole. Proovi lisada nimekirja",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_et.arb
+++ b/l10n/intl_et.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Jätka kuulamist",
   "noFavoriteReciters": "Ühtegi lemmikretsitaatorit pole. Proovi lisada nimekirja",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fa.arb
+++ b/l10n/intl_fa.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "ادامه گوش دادن",
   "noFavoriteReciters": "No favorite reciters. Try adding one to the list",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fa.arb
+++ b/l10n/intl_fa.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "ادامه گوش دادن",
+  "continueListening": "به گوش دادن ادامه دهید",
   "noFavoriteReciters": "No favorite reciters. Try adding one to the list",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fa.arb
+++ b/l10n/intl_fa.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "No favorite reciters. Try adding one to the list",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ff.arb
+++ b/l10n/intl_ff.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Jokku heɓaade",
   "noFavoriteReciters": "Alaa tafsirooɓe hatojinaɓe. Eto ɓeydude gooto e doggol nfol",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ff.arb
+++ b/l10n/intl_ff.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Jokku heɓaade",
+  "continueListening": "Jokku heɗtaade",
   "noFavoriteReciters": "Alaa tafsirooɓe hatojinaɓe. Eto ɓeydude gooto e doggol nfol",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ff.arb
+++ b/l10n/intl_ff.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Jokku heɗtaade",
+  "continueListening": "Jokkude heɗaade",
   "noFavoriteReciters": "Alaa tafsirooɓe hatojinaɓe. Eto ɓeydude gooto e doggol nfol",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ff.arb
+++ b/l10n/intl_ff.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Alaa tafsirooɓe hatojinaɓe. Eto ɓeydude gooto e doggol nfol",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fi.arb
+++ b/l10n/intl_fi.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Jatka kuuntelua",
+  "continueListening": "Jatka kuuntelemista",
   "noFavoriteReciters": "Ei suosikkitunnisteita. Yritä lisätä yksi listaan",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fi.arb
+++ b/l10n/intl_fi.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Ei suosikkitunnisteita. Yritä lisätä yksi listaan",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fi.arb
+++ b/l10n/intl_fi.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Jatka kuuntelua",
   "noFavoriteReciters": "Ei suosikkitunnisteita. Yritä lisätä yksi listaan",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -345,7 +345,7 @@
       }
     }
   },
-  "continueListening": "Continuer l'écoute",
+  "continueListening": "Continuer à écouter",
   "noFavoriteReciters": "Aucun réciteur préféré. Essayez d'en ajouter un à la liste",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -345,6 +345,7 @@
       }
     }
   },
+  "continueListening": "Continuer l'écoute",
   "noFavoriteReciters": "Aucun réciteur préféré. Essayez d'en ajouter un à la liste",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_gu.arb
+++ b/l10n/intl_gu.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "સાંભળવાનું ચાલુ રાખો",
   "noFavoriteReciters": "પસંદગીના લિસ્ટમાં કોઈ કારી નથી. લિસ્ટમાં ઉમેરવા માટે પ્રયાસ કરો",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_gu.arb
+++ b/l10n/intl_gu.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "પસંદગીના લિસ્ટમાં કોઈ કારી નથી. લિસ્ટમાં ઉમેરવા માટે પ્રયાસ કરો",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_he.arb
+++ b/l10n/intl_he.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "המשך האזנה",
   "noFavoriteReciters": "אין קוראים מועדפים. נסה להוסיף אחד לרשימה",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_he.arb
+++ b/l10n/intl_he.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "המשך האזנה",
+  "continueListening": "המשך להקשיב",
   "noFavoriteReciters": "אין קוראים מועדפים. נסה להוסיף אחד לרשימה",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_he.arb
+++ b/l10n/intl_he.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "אין קוראים מועדפים. נסה להוסיף אחד לרשימה",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hi.arb
+++ b/l10n/intl_hi.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "कोई पसंदीदा पाठक नहीं. सूची में एक जोड़ने का प्रयास करें",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hi.arb
+++ b/l10n/intl_hi.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "सुनना जारी रखें",
   "noFavoriteReciters": "कोई पसंदीदा पाठक नहीं. सूची में एक जोड़ने का प्रयास करें",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hr.arb
+++ b/l10n/intl_hr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušanje",
+  "continueListening": "Nastavi slušati",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na popis.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hr.arb
+++ b/l10n/intl_hr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Nastavi slušanje",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na popis.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hr.arb
+++ b/l10n/intl_hr.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na popis.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hr.arb
+++ b/l10n/intl_hr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušati",
+  "continueListening": "Nastavite slušati",
   "noFavoriteReciters": "Nema omiljenih učača. Pokušajte dodati jednog na popis.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hu.arb
+++ b/l10n/intl_hu.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Hallgatás folytatása",
+  "continueListening": "Hallgassa tovább",
   "noFavoriteReciters": "Nincsenek kedvenc recitálók. Próbálj hozzáadni egyet a listához",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hu.arb
+++ b/l10n/intl_hu.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nincsenek kedvenc recitálók. Próbálj hozzáadni egyet a listához",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_hu.arb
+++ b/l10n/intl_hu.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Hallgatás folytatása",
   "noFavoriteReciters": "Nincsenek kedvenc recitálók. Próbálj hozzáadni egyet a listához",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_id.arb
+++ b/l10n/intl_id.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Belum ada favorit qori. Silahkan ditambahkan ke dalam daftar",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_id.arb
+++ b/l10n/intl_id.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Lanjutkan mendengarkan",
   "noFavoriteReciters": "Belum ada favorit qori. Silahkan ditambahkan ke dalam daftar",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_it.arb
+++ b/l10n/intl_it.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nessun recitatore preferito. Prova ad aggiungerne uno alla lista",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_it.arb
+++ b/l10n/intl_it.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Continua ad ascoltare",
   "noFavoriteReciters": "Nessun recitatore preferito. Prova ad aggiungerne uno alla lista",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ja.arb
+++ b/l10n/intl_ja.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "聴き続ける",
+  "continueListening": "聞き続けます",
   "noFavoriteReciters": "お気に入りのリサイターはありません。リストに追加してみてください",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ja.arb
+++ b/l10n/intl_ja.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "聴き続ける",
   "noFavoriteReciters": "お気に入りのリサイターはありません。リストに追加してみてください",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ja.arb
+++ b/l10n/intl_ja.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "お気に入りのリサイターはありません。リストに追加してみてください",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ko.arb
+++ b/l10n/intl_ko.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "즐겨찾는 낭독자가 없습니다. 목록에 추가해보세요",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ko.arb
+++ b/l10n/intl_ko.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "계속 듣기",
   "noFavoriteReciters": "즐겨찾는 낭독자가 없습니다. 목록에 추가해보세요",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ku.arb
+++ b/l10n/intl_ku.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "هیچ قورئانخوێنێکی دڵخواز بونی نیە. دانەیەک زیاد بکە",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ku.arb
+++ b/l10n/intl_ku.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Guhdarîkirinê berdewam bike",
+  "continueListening": "Guhdarîkirinê bidomînin",
   "noFavoriteReciters": "هیچ قورئانخوێنێکی دڵخواز بونی نیە. دانەیەک زیاد بکە",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ku.arb
+++ b/l10n/intl_ku.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Guhdarîkirinê bidomîne",
+  "continueListening": "Guhdarîkirinê berdewam bike",
   "noFavoriteReciters": "هیچ قورئانخوێنێکی دڵخواز بونی نیە. دانەیەک زیاد بکە",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ku.arb
+++ b/l10n/intl_ku.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Guhdarîkirinê bidomîne",
   "noFavoriteReciters": "هیچ قورئانخوێنێکی دڵخواز بونی نیە. دانەیەک زیاد بکە",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lt.arb
+++ b/l10n/intl_lt.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Tęsti klausymą",
+  "continueListening": "Klausyk toliau",
   "noFavoriteReciters": "Nėra mėgstamų skaitytojų. Pridėkite vieną į sąrašą",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lt.arb
+++ b/l10n/intl_lt.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nėra mėgstamų skaitytojų. Pridėkite vieną į sąrašą",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lt.arb
+++ b/l10n/intl_lt.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Tęsti klausymą",
   "noFavoriteReciters": "Nėra mėgstamų skaitytojų. Pridėkite vieną į sąrašą",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lv.arb
+++ b/l10n/intl_lv.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Turpināt klausīties",
+  "continueListening": "Turpiniet klausīties",
   "noFavoriteReciters": "Nav neviena izlases lasītāja. Pievienojiet kādu sarakstam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lv.arb
+++ b/l10n/intl_lv.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Turpināt klausīties",
   "noFavoriteReciters": "Nav neviena izlases lasītāja. Pievienojiet kādu sarakstam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_lv.arb
+++ b/l10n/intl_lv.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nav neviena izlases lasītāja. Pievienojiet kādu sarakstam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_mk.arb
+++ b/l10n/intl_mk.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Продолжи со слушање",
+  "continueListening": "Продолжете да слушате",
   "noFavoriteReciters": "Нема омилени чтеци. Обидете се да додадете некој на листата",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_mk.arb
+++ b/l10n/intl_mk.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Нема омилени чтеци. Обидете се да додадете некој на листата",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_mk.arb
+++ b/l10n/intl_mk.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Продолжи со слушање",
   "noFavoriteReciters": "Нема омилени чтеци. Обидете се да додадете некој на листата",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ms.arb
+++ b/l10n/intl_ms.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Tiada qari kegemaran. Sila tambah ke senarai",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ms.arb
+++ b/l10n/intl_ms.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Teruskan mendengar",
   "noFavoriteReciters": "Tiada qari kegemaran. Sila tambah ke senarai",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_nl.arb
+++ b/l10n/intl_nl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Doorgaan met luisteren",
   "noFavoriteReciters": "Geen favoriete reciters. Probeer er één toe te voegen aan de lijst",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_nl.arb
+++ b/l10n/intl_nl.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Geen favoriete reciters. Probeer er één toe te voegen aan de lijst",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_nl.arb
+++ b/l10n/intl_nl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Verder luisteren",
+  "continueListening": "Blijf luisteren",
   "noFavoriteReciters": "Geen favoriete reciters. Probeer er één toe te voegen aan de lijst",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_nl.arb
+++ b/l10n/intl_nl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Doorgaan met luisteren",
+  "continueListening": "Verder luisteren",
   "noFavoriteReciters": "Geen favoriete reciters. Probeer er één toe te voegen aan de lijst",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_no.arb
+++ b/l10n/intl_no.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Fortsett å lytte",
   "noFavoriteReciters": "Ingen favorittoppskrifter. Prøv å legge til en i listen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_no.arb
+++ b/l10n/intl_no.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Ingen favorittoppskrifter. Prøv å legge til en i listen",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_pl.arb
+++ b/l10n/intl_pl.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Brak ulubionych motywów. Spróbuj dodać jeden do listy",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_pl.arb
+++ b/l10n/intl_pl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Kontynuuj słuchanie",
   "noFavoriteReciters": "Brak ulubionych motywów. Spróbuj dodać jeden do listy",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_pt.arb
+++ b/l10n/intl_pt.arb
@@ -1,1 +1,3 @@
-{"@@locale": "pt"}
+{"@@locale": "pt",
+  "continueListening": "Continue listening"
+}

--- a/l10n/intl_pt.arb
+++ b/l10n/intl_pt.arb
@@ -1,3 +1,3 @@
 {"@@locale": "pt",
-  "continueListening": "Continue listening"
+  "continueListening": "Continuar a ouvir"
 }

--- a/l10n/intl_pt.arb
+++ b/l10n/intl_pt.arb
@@ -1,3 +1,3 @@
 {"@@locale": "pt",
-  "continueListening": "Continuar a ouvir"
+  "continueListening": "Continuar ouvindo"
 }

--- a/l10n/intl_pt_BR.arb
+++ b/l10n/intl_pt_BR.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Continuar ouvindo",
   "noFavoriteReciters": "Nenhum recitador favorito. Primeiramente adicione um à lista.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_pt_BR.arb
+++ b/l10n/intl_pt_BR.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nenhum recitador favorito. Primeiramente adicione um à lista.",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_pt_PT.arb
+++ b/l10n/intl_pt_PT.arb
@@ -240,6 +240,7 @@
   "allReciters": "Todos os Recitadores",
   "reciterAddedToFavorites": "Recitador {name} adicionado aos favoritos",
   "reciterRemovedFromFavorites": "Recitador {name} removido dos favoritos",
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Sem recitadores favoritos. Tente adicionar um à lista.",
   "noReciterSearchResult": "Nenhum resultado encontrado para a sua pesquisa",
   "searchForReciter": "Pesquisar por um recitador",

--- a/l10n/intl_pt_PT.arb
+++ b/l10n/intl_pt_PT.arb
@@ -240,7 +240,7 @@
   "allReciters": "Todos os Recitadores",
   "reciterAddedToFavorites": "Recitador {name} adicionado aos favoritos",
   "reciterRemovedFromFavorites": "Recitador {name} removido dos favoritos",
-  "continueListening": "Continue listening",
+  "continueListening": "Continuar a ouvir",
   "noFavoriteReciters": "Sem recitadores favoritos. Tente adicionar um à lista.",
   "noReciterSearchResult": "Nenhum resultado encontrado para a sua pesquisa",
   "searchForReciter": "Pesquisar por um recitador",

--- a/l10n/intl_ro.arb
+++ b/l10n/intl_ro.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Continuă ascultarea",
   "noFavoriteReciters": "Niciun reciter favorit. Încearcă să adaugi unul la listă",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ro.arb
+++ b/l10n/intl_ro.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continuă ascultarea",
+  "continueListening": "Continuați să ascultați",
   "noFavoriteReciters": "Niciun reciter favorit. Încearcă să adaugi unul la listă",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ro.arb
+++ b/l10n/intl_ro.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Niciun reciter favorit. Încearcă să adaugi unul la listă",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ro.arb
+++ b/l10n/intl_ro.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continuați să ascultați",
+  "continueListening": "Ascultă în continuare",
   "noFavoriteReciters": "Niciun reciter favorit. Încearcă să adaugi unul la listă",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ru.arb
+++ b/l10n/intl_ru.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Нет любимых редакторов. Попробуйте добавить один в список",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ru.arb
+++ b/l10n/intl_ru.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Продолжить прослушивание",
   "noFavoriteReciters": "Нет любимых редакторов. Попробуйте добавить один в список",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sl.arb
+++ b/l10n/intl_sl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nadaljuj poslušanje",
+  "continueListening": "Nadaljujte s poslušanjem",
   "noFavoriteReciters": "Ni najljubših recitatorjev. Poskusite dodati vsaj enega na seznam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sl.arb
+++ b/l10n/intl_sl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Nadaljuj s poslušanjem",
   "noFavoriteReciters": "Ni najljubših recitatorjev. Poskusite dodati vsaj enega na seznam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sl.arb
+++ b/l10n/intl_sl.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nadaljuj s poslušanjem",
+  "continueListening": "Nadaljuj poslušanje",
   "noFavoriteReciters": "Ni najljubših recitatorjev. Poskusite dodati vsaj enega na seznam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sl.arb
+++ b/l10n/intl_sl.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Ni najljubših recitatorjev. Poskusite dodati vsaj enega na seznam",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sq.arb
+++ b/l10n/intl_sq.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sq.arb
+++ b/l10n/intl_sq.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Vazhdo të dëgjosh",
+  "continueListening": "Vazhdo dëgjimin",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sq.arb
+++ b/l10n/intl_sq.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Vazhdo dëgjimin",
+  "continueListening": "Vazhdoni të dëgjoni",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sq.arb
+++ b/l10n/intl_sq.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Vazhdo të dëgjosh",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sr.arb
+++ b/l10n/intl_sr.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nema omiljenih učača. Dodajte nekog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sr.arb
+++ b/l10n/intl_sr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Nastavi slušanje",
   "noFavoriteReciters": "Nema omiljenih učača. Dodajte nekog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sr.arb
+++ b/l10n/intl_sr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Nastavi slušanje",
+  "continueListening": "Настави са слушањем",
   "noFavoriteReciters": "Nema omiljenih učača. Dodajte nekog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sr.arb
+++ b/l10n/intl_sr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Настави са слушањем",
+  "continueListening": "Наставите са слушањем",
   "noFavoriteReciters": "Nema omiljenih učača. Dodajte nekog na listu",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sv.arb
+++ b/l10n/intl_sv.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Fortsätt lyssna",
   "noFavoriteReciters": "Inga favoritrecitatörer. Försök att lägga till en i listan",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_sv.arb
+++ b/l10n/intl_sv.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Inga favoritrecitatörer. Försök att lägga till en i listan",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ta.arb
+++ b/l10n/intl_ta.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "தொடர்ந்து கேளுங்கள்",
   "noFavoriteReciters": "விருப்பமான பாடகர் இல்லை. பட்டியலில் ஒன்றைச் சேர்க்க முயற்சிக்கவும்",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ta.arb
+++ b/l10n/intl_ta.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "கேட்பதை தொடரவும்",
+  "continueListening": "தொடர்ந்து கேளுங்கள்",
   "noFavoriteReciters": "விருப்பமான பாடகர் இல்லை. பட்டியலில் ஒன்றைச் சேர்க்க முயற்சிக்கவும்",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ta.arb
+++ b/l10n/intl_ta.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "தொடர்ந்து கேளுங்கள்",
+  "continueListening": "கேட்பதை தொடரவும்",
   "noFavoriteReciters": "விருப்பமான பாடகர் இல்லை. பட்டியலில் ஒன்றைச் சேர்க்க முயற்சிக்கவும்",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ta.arb
+++ b/l10n/intl_ta.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "விருப்பமான பாடகர் இல்லை. பட்டியலில் ஒன்றைச் சேர்க்க முயற்சிக்கவும்",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_th.arb
+++ b/l10n/intl_th.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "ฟังต่อ",
   "noFavoriteReciters": "ไม่มีผู้อ่านที่ชื่นชอบ ลองเพิ่มรายการหนึ่งรายการ",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_th.arb
+++ b/l10n/intl_th.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "ไม่มีผู้อ่านที่ชื่นชอบ ลองเพิ่มรายการหนึ่งรายการ",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_tr.arb
+++ b/l10n/intl_tr.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Favori okuyucunuz yoktur, Listeye bir tane eklemeyi deneyin",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_tr.arb
+++ b/l10n/intl_tr.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Dinlemeye devam et",
   "noFavoriteReciters": "Favori okuyucunuz yoktur, Listeye bir tane eklemeyi deneyin",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_uk.arb
+++ b/l10n/intl_uk.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Немає улюблених читців. Спробуйте додати одного до списку",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_uk.arb
+++ b/l10n/intl_uk.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Продовжити прослуховування",
+  "continueListening": "Слухайте далі",
   "noFavoriteReciters": "Немає улюблених читців. Спробуйте додати одного до списку",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_uk.arb
+++ b/l10n/intl_uk.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Продовжити прослуховування",
   "noFavoriteReciters": "Немає улюблених читців. Спробуйте додати одного до списку",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ur.arb
+++ b/l10n/intl_ur.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "سننا جاری رکھیں",
   "noFavoriteReciters": "کوئی پسندیدہ تلاوت کرنے والا نہیں۔ فہرست میں ایک شامل کرنے کی کوشش کریں۔",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_ur.arb
+++ b/l10n/intl_ur.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "کوئی پسندیدہ تلاوت کرنے والا نہیں۔ فہرست میں ایک شامل کرنے کی کوشش کریں۔",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_vi.arb
+++ b/l10n/intl_vi.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_vi.arb
+++ b/l10n/intl_vi.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "Tiếp tục nghe",
   "noFavoriteReciters": "Nuk ka recitues të preferuar. Provoni të shtoni një në listë",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_zh.arb
+++ b/l10n/intl_zh.arb
@@ -341,6 +341,7 @@
       }
     }
   },
+  "continueListening": "Continue listening",
   "noFavoriteReciters": "没有收藏的最近版。请尝试在列表中添加一个",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"

--- a/l10n/intl_zh.arb
+++ b/l10n/intl_zh.arb
@@ -341,7 +341,7 @@
       }
     }
   },
-  "continueListening": "Continue listening",
+  "continueListening": "继续收听",
   "noFavoriteReciters": "没有收藏的最近版。请尝试在列表中添加一个",
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"


### PR DESCRIPTION
## Summary

- Adds `continueListening` key to all 52 locale `.arb` files
- Real translations: `ar` (Arabic) and `fr` (French)
- Remaining languages use English fallback — Crowdin AI will update them after merge into `dev`
- Only ARB files touched, no generated Dart files

## Related
- Linked to android-tv-app PR #2158