### PR TITLE
Feat: Add onboarding ID tutorial keys

### DIFF
--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -493,5 +493,15 @@
   "launchModeMainPrayer": "أوقات الصلاة الرئيسية",
   "launchModeSecondaryPrayer": "أوقات الصلاة الثانوية",
   "timezone": "المنطقة الزمنية",
-  "wifi": "واي فاي"
+  "wifi": "واي فاي",
+  "tutorialGetStarted": "ابدأ في 4 خطوات بسيطة",
+  "tutorialDontHaveId": "ليس لديك معرّف مسجد بعد؟ إليك الطريقة:",
+  "tutorialStep1": "اذهب إلى mawaqit.net وأنشئ حساباً",
+  "tutorialStep2": "سجّل مسجدك بالصور والعنوان",
+  "tutorialStep3": "احصل على معرّف المسجد الفريد من لوحة التحكم",
+  "tutorialStep4": "أدخل المعرّف هنا لربط شاشة التلفزيون",
+  "tutorialStep": "الخطوة {step}  ",
+  "tutorialScanToRegister": "امسح للتسجيل",
+  "tutorialScanDescription": "استخدم هاتفك لإنشاء حساب على mawaqit.net",
+  "tutorialFullTutorial": "الشرح الكامل"
 }

--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -545,5 +545,50 @@
   "wifi": "WIFI",
   "@wifi": {
     "description": "Title for the WIFI setting item"
+  },
+  "tutorialGetStarted": "Get started in 4 simple steps",
+  "@tutorialGetStarted": {
+    "description": "Title for the mosque ID tutorial section"
+  },
+  "tutorialDontHaveId": "Don't have a Mosque ID yet? Here's how:",
+  "@tutorialDontHaveId": {
+    "description": "Subtitle for the mosque ID tutorial section"
+  },
+  "tutorialStep1": "Go to mawaqit.net and create an account",
+  "@tutorialStep1": {
+    "description": "Tutorial step 1 instruction"
+  },
+  "tutorialStep2": "Register your mosque with photos & address",
+  "@tutorialStep2": {
+    "description": "Tutorial step 2 instruction"
+  },
+  "tutorialStep3": "Get your unique Mosque ID from your dashboard",
+  "@tutorialStep3": {
+    "description": "Tutorial step 3 instruction"
+  },
+  "tutorialStep4": "Enter the ID here to connect your TV display",
+  "@tutorialStep4": {
+    "description": "Tutorial step 4 instruction"
+  },
+  "tutorialStep": "Step {step}  ",
+  "@tutorialStep": {
+    "description": "Step label prefix with step number",
+    "placeholders": {
+      "step": {
+        "type": "String"
+      }
+    }
+  },
+  "tutorialScanToRegister": "Scan to register",
+  "@tutorialScanToRegister": {
+    "description": "Label next to QR code for registration"
+  },
+  "tutorialScanDescription": "Use your phone to create an account on mawaqit.net",
+  "@tutorialScanDescription": {
+    "description": "Description below the scan to register label"
+  },
+  "tutorialFullTutorial": "Full tutorial",
+  "@tutorialFullTutorial": {
+    "description": "Label for the full video tutorial section"
   }
 }

--- a/l10n/intl_fr.arb
+++ b/l10n/intl_fr.arb
@@ -493,5 +493,15 @@
   "launchModeMainPrayer": "Horaires de prière principaux",
   "launchModeSecondaryPrayer": "Horaires de prière secondaires",
   "timezone": "Fuseau horaire",
-  "wifi": "WiFi"
+  "wifi": "WiFi",
+  "tutorialGetStarted": "Commencez en 4 étapes simples",
+  "tutorialDontHaveId": "Vous n'avez pas encore d'identifiant de mosquée ? Voici comment :",
+  "tutorialStep1": "Allez sur mawaqit.net et créez un compte",
+  "tutorialStep2": "Enregistrez votre mosquée avec photos et adresse",
+  "tutorialStep3": "Obtenez votre identifiant unique depuis votre tableau de bord",
+  "tutorialStep4": "Entrez l'identifiant ici pour connecter votre écran TV",
+  "tutorialStep": "Étape {step}  ",
+  "tutorialScanToRegister": "Scannez pour vous inscrire",
+  "tutorialScanDescription": "Utilisez votre téléphone pour créer un compte sur mawaqit.net",
+  "tutorialFullTutorial": "Tutoriel complet"
 }

--- a/lib/src/generated/mawaqit_tv_localizations.dart
+++ b/lib/src/generated/mawaqit_tv_localizations.dart
@@ -2286,6 +2286,66 @@ abstract class MawaqitTvLocalizations {
   /// In en, this message translates to:
   /// **'WIFI'**
   String get wifi;
+
+  /// Title for the mosque ID tutorial section
+  ///
+  /// In en, this message translates to:
+  /// **'Get started in 4 simple steps'**
+  String get tutorialGetStarted;
+
+  /// Subtitle for the mosque ID tutorial section
+  ///
+  /// In en, this message translates to:
+  /// **'Don\'t have a Mosque ID yet? Here\'s how:'**
+  String get tutorialDontHaveId;
+
+  /// Tutorial step 1 instruction
+  ///
+  /// In en, this message translates to:
+  /// **'Go to mawaqit.net and create an account'**
+  String get tutorialStep1;
+
+  /// Tutorial step 2 instruction
+  ///
+  /// In en, this message translates to:
+  /// **'Register your mosque with photos & address'**
+  String get tutorialStep2;
+
+  /// Tutorial step 3 instruction
+  ///
+  /// In en, this message translates to:
+  /// **'Get your unique Mosque ID from your dashboard'**
+  String get tutorialStep3;
+
+  /// Tutorial step 4 instruction
+  ///
+  /// In en, this message translates to:
+  /// **'Enter the ID here to connect your TV display'**
+  String get tutorialStep4;
+
+  /// Step label prefix with step number
+  ///
+  /// In en, this message translates to:
+  /// **'Step {step}  '**
+  String tutorialStep(String step);
+
+  /// Label next to QR code for registration
+  ///
+  /// In en, this message translates to:
+  /// **'Scan to register'**
+  String get tutorialScanToRegister;
+
+  /// Description below the scan to register label
+  ///
+  /// In en, this message translates to:
+  /// **'Use your phone to create an account on mawaqit.net'**
+  String get tutorialScanDescription;
+
+  /// Label for the full video tutorial section
+  ///
+  /// In en, this message translates to:
+  /// **'Full tutorial'**
+  String get tutorialFullTutorial;
 }
 
 class _MawaqitTvLocalizationsDelegate extends LocalizationsDelegate<MawaqitTvLocalizations> {

--- a/lib/src/generated/mawaqit_tv_localizations_ar.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ar.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsAr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'واي فاي';
+
+  @override
+  String get tutorialGetStarted => 'ابدأ في 4 خطوات بسيطة';
+
+  @override
+  String get tutorialDontHaveId => 'ليس لديك معرّف مسجد بعد؟ إليك الطريقة:';
+
+  @override
+  String get tutorialStep1 => 'اذهب إلى mawaqit.net وأنشئ حساباً';
+
+  @override
+  String get tutorialStep2 => 'سجّل مسجدك بالصور والعنوان';
+
+  @override
+  String get tutorialStep3 => 'احصل على معرّف المسجد الفريد من لوحة التحكم';
+
+  @override
+  String get tutorialStep4 => 'أدخل المعرّف هنا لربط شاشة التلفزيون';
+
+  @override
+  String tutorialStep(String step) {
+    return 'الخطوة $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'امسح للتسجيل';
+
+  @override
+  String get tutorialScanDescription => 'استخدم هاتفك لإنشاء حساب على mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'الشرح الكامل';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_az.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_az.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsAz extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ba.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ba.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsBa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_bg.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_bg.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsBg extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_bn.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_bn.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsBn extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_bs.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_bs.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsBs extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ca.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ca.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsCa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_cnr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_cnr.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsCnr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_cs.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_cs.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsCs extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_da.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_da.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsDa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_de.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_de.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsDe extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WLAN';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_el.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_el.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsEl extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_en.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_en.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsEn extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WIFI';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_es.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_es.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsEs extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_et.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_et.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsEt extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_fa.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_fa.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsFa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'وای‌فای';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ff.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ff.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsFf extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_fi.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_fi.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsFi extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_fr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_fr.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsFr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Commencez en 4 étapes simples';
+
+  @override
+  String get tutorialDontHaveId => 'Vous n\'avez pas encore d\'identifiant de mosquée ? Voici comment :';
+
+  @override
+  String get tutorialStep1 => 'Allez sur mawaqit.net et créez un compte';
+
+  @override
+  String get tutorialStep2 => 'Enregistrez votre mosquée avec photos et adresse';
+
+  @override
+  String get tutorialStep3 => 'Obtenez votre identifiant unique depuis votre tableau de bord';
+
+  @override
+  String get tutorialStep4 => 'Entrez l\'identifiant ici pour connecter votre écran TV';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Étape $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scannez pour vous inscrire';
+
+  @override
+  String get tutorialScanDescription => 'Utilisez votre téléphone pour créer un compte sur mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Tutoriel complet';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_gu.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_gu.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsGu extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_he.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_he.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsHe extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_hi.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_hi.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsHi extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'वाईफाई';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_hr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_hr.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsHr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_hu.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_hu.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsHu extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_id.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_id.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsId extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_it.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_it.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsIt extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ja.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ja.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsJa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ko.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ko.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsKo extends MawaqitTvLocalizations {
 
   @override
   String get wifi => '와이파이';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ku.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ku.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsKu extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_lt.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_lt.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsLt extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_lv.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_lv.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsLv extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_mk.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_mk.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsMk extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ms.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ms.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsMs extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_nl.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_nl.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsNl extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_no.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_no.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsNo extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_pl.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_pl.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsPl extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_pt.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_pt.dart
@@ -1072,6 +1072,38 @@ class MawaqitTvLocalizationsPt extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/src/generated/mawaqit_tv_localizations_ro.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ro.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsRo extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ru.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ru.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsRu extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_sl.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_sl.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsSl extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_sq.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_sq.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsSq extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_sr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_sr.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsSr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_sv.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_sv.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsSv extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ta.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ta.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsTa extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'வைஃபை';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_th.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_th.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsTh extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_tr.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_tr.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsTr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_uk.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_uk.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsUk extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_ur.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ur.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsUr extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'وائی فائی';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_vi.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_vi.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsVi extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }

--- a/lib/src/generated/mawaqit_tv_localizations_zh.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_zh.dart
@@ -1072,4 +1072,36 @@ class MawaqitTvLocalizationsZh extends MawaqitTvLocalizations {
 
   @override
   String get wifi => 'WiFi';
+
+  @override
+  String get tutorialGetStarted => 'Get started in 4 simple steps';
+
+  @override
+  String get tutorialDontHaveId => 'Don\'t have a Mosque ID yet? Here\'s how:';
+
+  @override
+  String get tutorialStep1 => 'Go to mawaqit.net and create an account';
+
+  @override
+  String get tutorialStep2 => 'Register your mosque with photos & address';
+
+  @override
+  String get tutorialStep3 => 'Get your unique Mosque ID from your dashboard';
+
+  @override
+  String get tutorialStep4 => 'Enter the ID here to connect your TV display';
+
+  @override
+  String tutorialStep(String step) {
+    return 'Step $step  ';
+  }
+
+  @override
+  String get tutorialScanToRegister => 'Scan to register';
+
+  @override
+  String get tutorialScanDescription => 'Use your phone to create an account on mawaqit.net';
+
+  @override
+  String get tutorialFullTutorial => 'Full tutorial';
 }


### PR DESCRIPTION
## Summary
Adds 10 new localization keys consumed by the mosque ID tutorial widget in the TV app (mawaqit/android-tv-app#2266):

- `tutorialGetStarted`, `tutorialDontHaveId`
- `tutorialStep1`..`tutorialStep4`, `tutorialStep` (with `{step}` placeholder)
- `tutorialScanToRegister`, `tutorialScanDescription`, `tutorialFullTutorial`

Replaces #31 (stale, conflicted with current `dev` after the duha / settings-menu / continue-listening / iqama-show-clock merges). Generated `.dart` files were regenerated cleanly via `flutter gen-l10n` on top of latest `dev`.

Closes mawaqit/android-tv-app#1777

## Translations
- ✅ EN, FR, AR — fully translated
- ⚠️ Other 50+ locales — fall back to English; translators will need to backfill before launch

## Test plan
- [x] `flutter pub get` resolves
- [x] `flutter gen-l10n` runs cleanly (only "untranslated message(s)" warnings, expected)
- [x] All 10 keys present on `MawaqitTvLocalizations` and consumed by mawaqit/android-tv-app#2266
- [ ] Translators backfill non-EN/FR/AR locales (separate PR)