### PR TITLE
fix: correct Arabic name for Rabi al-Thani month

### DIFF
--- a/l10n/intl_ar.arb
+++ b/l10n/intl_ar.arb
@@ -141,7 +141,7 @@
   "muharram": "محرم",
   "safar": "صفر",
   "rabiAlawwal": "ربيع الأول",
-  "rabiAlthani": "ربيع الثاني",
+  "rabiAlthani": "ربيع الآخر",
   "jumadaAlula": "جُمادى الأولى",
   "jumadaAlakhirah": "جُمادى الآخرة",
   "rajab": "رجب",

--- a/lib/src/generated/mawaqit_tv_localizations_ar.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_ar.dart
@@ -307,7 +307,7 @@ class MawaqitTvLocalizationsAr extends MawaqitTvLocalizations {
   String get rabiAlawwal => 'ربيع الأول';
 
   @override
-  String get rabiAlthani => 'ربيع الثاني';
+  String get rabiAlthani => 'ربيع الآخر';
 
   @override
   String get jumadaAlula => 'جُمادى الأولى';


### PR DESCRIPTION
"ربيع الثاني" was used for the 4th Hijri month; the correct Arabic name is "ربيع الآخر" (jumadaAlakhirah already used the equivalent "الآخرة" form, this brings rabiAlthani in line).

Related to mawaqit/android-tv-app#2267