### PR TITLE
chore(crowdin): give human approval priority over pipeline output

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -25,7 +25,9 @@ jobs:
           upload_sources: true
           upload_translations: true
           download_translations: false
-          auto_approve_imported: true
+          # Imported repo text arrives as a suggestion, not a verdict. Approval is
+          # a human act — see the round trip described in the PR body.
+          auto_approve_imported: false
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
@@ -34,7 +36,10 @@ jobs:
         uses: crowdin/github-action@v2
         with:
           command: 'pre-translate'
-          command_args: '--method ai --ai-prompt 332920 --translate-untranslated-only'
+          # --auto-approve-option none is already the CLI default; pinned so a future
+          # edit can't quietly promote machine output to approved. --label lets us
+          # filter and bulk-review everything the AI wrote.
+          command_args: '--method ai --ai-prompt 332920 --translate-untranslated-only --auto-approve-option none --label ai'
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
@@ -54,6 +59,10 @@ jobs:
           upload_translations: false
           download_translations: true
           skip_untranslated_strings: true
+          # Only human-approved text reaches the app. Combined with
+          # skip_untranslated_strings, unapproved strings are omitted from the .arb
+          # and Flutter falls back to English — preferable to shipping a wrong hadith.
+          export_only_approved: true
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'chore(l10n): sync translations from Crowdin'


### PR DESCRIPTION
Approval in this project is currently being manufactured by the pipeline rather than given by a person. This makes it a human act again.

### The round trip

```
AI pre-translate writes into Crowdin      → unapproved (correct)
download PR exports it anyway             → lands in l10n/intl_*.arb
next run: upload_translations re-imports  → auto_approve_imported: true
                                          → machine text is now "Approved"
```

Nothing here reads the language. One flag turns generated output into a green approved checkmark under whoever owns `CROWDIN_PERSONAL_TOKEN`.

That is how the Swedish `duaaBetweenSalahAndAdhan` — whose translation reverses the meaning of the hadith — came to sit in Crowdin marked approved, and why #2154 has survived three attempts to fix it since April.

### Changes

| Setting | Was | Now | Why |
|---|---|---|---|
| `auto_approve_imported` | `true` | `false` | Repo text arrives as a suggestion, not a verdict |
| `export_only_approved` | *(unset)* | `true` | Only human-approved text reaches the app |
| `--auto-approve-option` | *(unset)* | `none` | Already the CLI default; pinned so it can't be quietly promoted |
| `--label` | *(unset)* | `ai` | Machine output stays filterable for bulk review |

`export_only_approved` combined with the existing `skip_untranslated_strings: true` means unapproved strings are **omitted** from the exported `.arb`, so Flutter falls back to English. For religious text that is the correct failure mode — English beats a reversed hadith.

### Before merging, please read this

**This is not retroactive.** Swedish currently sits at ~98% approved, most of it stamped by this pipeline rather than reviewed. Those approvals keep their status. They need bulk-unapproving (filterable in Crowdin by approver and date) for any language nobody has natively reviewed.

**Sequence matters.** Merge this, run a proofreader pass on the languages you actually care about, and only then expect exports to look healthy. If approvals are still thin when the next sync runs, coverage drops and English appears where machine text used to be. That is the intended behaviour, but it will read as a regression to anyone who does not know why.

**Config alone is not enough.** Approving is a Proofreader capability. While anyone can approve any language, this only closes the automated path — grant Proofreader per-language to people who actually read that language.

### Related

- Issue #2154 — the Swedish translations this was masking
- mawaqit/mawaqit-tv-l10n#58 — fixes the string in the repo; merge it, then dispatch this workflow manually (it won't fire on its own, the trigger only watches `l10n/intl_en.arb`)
- mawaqit/mawaqit-tv-l10n#35 — stale since March, carries the broken string, would revert #58. Close rather than merge.
