### PR TITLE
fix(crowdin): stop duplicate source upload and translation overwrite

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -19,18 +19,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Upload sources and translations to Crowdin
-        uses: crowdin/github-action@v2
-        with:
-          upload_sources: true
-          upload_translations: true
-          download_translations: false
-          # Imported repo text arrives as a suggestion, not a verdict. Approval is
-          # a human act — see the round trip described in the PR body.
-          auto_approve_imported: false
-        env:
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      # Sources are uploaded by Crowdin's own GitHub VCS integration (Integrations tab),
+      # not here — running both created a duplicate, out-of-sync source file in Crowdin.
+      #
+      # Translations are never uploaded from the repo back to Crowdin either — Crowdin
+      # is the one-way source of truth for translation text. Re-uploading the repo's
+      # own (possibly stale) files on every dev merge overwrote human approvals in
+      # Crowdin with old committed text, which is what happened repeatedly to the
+      # pt-PT translations in issue #2289 (and, before auto_approve_imported was
+      # turned off in a8e6ff5, the same round trip is what let a reversed-meaning
+      # Swedish hadith sit "Approved" in issue #2154).
+      - name: Wait for Crowdin's native VCS sync to pick up the new sources
+        run: sleep 60
 
       - name: Pre-translate with AI
         uses: crowdin/github-action@v2


### PR DESCRIPTION
## Summary
- Removes the workflow's own source upload — Crowdin's native GitHub VCS integration (Integrations tab, tracking `dev`) already uploads `intl_en.arb` on every push. Running both created a second, out-of-sync `intl_en.arb` in the Crowdin project root, which is what was confusing translators (they'd see two source files).
- Removes `upload_translations` from the recurring sync job. It re-uploaded the repo's own (possibly stale) `intl_*.arb` files back into Crowdin on every `dev` merge that touched `intl_en.arb` — even merges unrelated to translations — overwriting human approvals already made in the Crowdin UI with old committed text.
- Adds a short wait before AI pre-translate so it runs against sources the native integration has actually finished syncing, since upload is no longer done inline in this job.

## Why
- The duplicate source folder in Crowdin was traced to this workflow's `upload_sources: true` racing Crowdin's own VCS integration — see the `[repo] dev` branch folder vs. the flat `l10n` folder both showing `intl_en.arb`.
- The translation-overwrite behavior matches the pattern reported in #2289: MShoebPT's approved European Portuguese (pt-PT) translations kept reverting to Brazilian Portuguese content. `upload_translations: true` re-imports the repo's committed arb files on every unrelated `dev` merge, clobbering whatever was just approved in Crowdin before the corresponding download PR had a chance to land.
- This is the same class of bug already called out in `a8e6ff5`'s commit message for issue #2154 (a reversed-meaning Swedish hadith that kept coming back "Approved"). That commit fixed the approval side (`auto_approve_imported: false`); this PR fixes the underlying overwrite by not uploading translations from the repo at all. It's also a re-application of an earlier fix (`366b786`, "let Crowdin be source of truth for translations") that was reverted a minute later for what was meant to be a one-time seed sync and never turned back off.

Closes https://github.com/mawaqit/android-tv-app/issues/2154
