### PR TITLE
fix: translate Shuruk to Sunrise in English locale

### DIFF
--- a/l10n/intl_en.arb
+++ b/l10n/intl_en.arb
@@ -163,7 +163,7 @@
   },
   "jumuaaScreenTitle": "Jumuaa Time",
   "jumuaaHadith": "The Prophet ﷺ (peace and blessings of Allah be upon him) said “Whoever does the ablutions perfectly then goes to jumua and then listens and is silent, he is forgiven what is between that time and the following Friday and three more days and the one who touches stones has certainly made a futility”",
-  "shuruk": "Shuruk",
+  "shuruk": "Sunrise",
   "duha": "Duha",
   "duhaTime": "Duha Time",
   "reset": "Reset",

--- a/lib/src/generated/mawaqit_tv_localizations.dart
+++ b/lib/src/generated/mawaqit_tv_localizations.dart
@@ -720,7 +720,7 @@ abstract class MawaqitTvLocalizations {
   /// No description provided for @shuruk.
   ///
   /// In en, this message translates to:
-  /// **'Shuruk'**
+  /// **'Sunrise'**
   String get shuruk;
 
   /// No description provided for @duha.

--- a/lib/src/generated/mawaqit_tv_localizations_en.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_en.dart
@@ -274,7 +274,7 @@ class MawaqitTvLocalizationsEn extends MawaqitTvLocalizations {
   String get jumuaaHadith => 'The Prophet ﷺ (peace and blessings of Allah be upon him) said “Whoever does the ablutions perfectly then goes to jumua and then listens and is silent, he is forgiven what is between that time and the following Friday and three more days and the one who touches stones has certainly made a futility”';
 
   @override
-  String get shuruk => 'Shuruk';
+  String get shuruk => 'Sunrise';
 
   @override
   String get duha => 'Duha';


### PR DESCRIPTION
## Summary
- UK mosque admins requested that the English "Shuruk" label be translated to "Sunrise" to match the Mawaqit mobile app and better serve English-speaking congregations.
- Changes `shuruk` in `l10n/intl_en.arb` from `"Shuruk"` to `"Sunrise"` and regenerates the Dart localization files (`flutter gen-l10n`).

Fixes mawaqit/android-tv-app#2207

