### PR TITLE
fix(id): use generic Eid prayer label instead of Idul Fitri-specific

### DIFF
--- a/l10n/intl_id.arb
+++ b/l10n/intl_id.arb
@@ -148,7 +148,7 @@
   "dhuAlhijjah": "Dzulhijjah",
   "duaaBetweenSalahAndAdhan": "Dari sahabat Anas bin Malik (رضي الله عنه), Rasulullah ﷺ bersabda,\nSesungguhnya doa yang tidak tertolak adalah doa (yang dipanjatkan) di antara adzan dan iqamah, maka berdoalah (di waktu itu).” (HR. Ahmad no. 12584).",
   "salatKhayrMinaNawm": "Assalatu khayrun mina nawm",
-  "salatElEid": "Salat Idul Fitri",
+  "salatElEid": "Salat Id",
   "webView": "Mengaktifkan Mode Lama",
   "developersHomeScreen": "Layar beranda pengembang",
   "onlineHome": "Beranda Online",

--- a/lib/src/generated/mawaqit_tv_localizations_id.dart
+++ b/lib/src/generated/mawaqit_tv_localizations_id.dart
@@ -340,7 +340,7 @@ class MawaqitTvLocalizationsId extends MawaqitTvLocalizations {
   String get salatKhayrMinaNawm => 'Assalatu khayrun mina nawm';
 
   @override
-  String get salatElEid => 'Salat Idul Fitri';
+  String get salatElEid => 'Salat Id';
 
   @override
   String get webView => 'Mengaktifkan Mode Lama';


### PR DESCRIPTION
## Summary
- `salatElEid` in Indonesian was hardcoded to "Salat Idul Fitri", which is wrong during Eid al-Adha.
- Changed it to the generic "Salat Id" (Eid Prayer), matching how every other locale phrases this key (none of them specialize to one Eid).

Fixes mawaqit/android-tv-app#2293

